### PR TITLE
Update Git and GitHub setup instructions

### DIFF
--- a/course_prerequisites/00_linux.md
+++ b/course_prerequisites/00_linux.md
@@ -74,6 +74,27 @@ If `git` is not already available on your machine you can try to install it via 
 sudo apt-get install git
 ```
 
+You'll know it has worked when you can get the Git version by running
+
+```
+git --version
+```
+
+which should show that you have a [recent](https://en.wikipedia.org/wiki/Git#Releases) copy of Git. If your version is more than 18 months old, please update it.
+
+You will need to set at least your email address and name, for which you can follow the **Your Identity** section of [First Time Git Setup](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
+
+You can check that they have been set correctly by running `git config user.name` and `git config user.email`.
+
+## GitHub
+
+For the Git part of the course, you will need access to GitHub. You will need to
+
+1. [Sign up](https://github.com/join)
+2. [Generate an SSH key pair](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+3. [Add the public key to your GitHub account and the private key to your computer's keychain](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+4. Lastly, you should [test your SSH connection](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)
+
 ## Editor
 
 Many different text editors suitable for programming are available.

--- a/course_prerequisites/01_mac.md
+++ b/course_prerequisites/01_mac.md
@@ -18,7 +18,20 @@ You may also install `Xcode` from the app store if you wish, but it is not neede
 
 ## Git
 
-The `XCode` command line tools come with `Git` so no need to do anything more.
+The `XCode` command line tools come with `Git` so no need to do anything more, as long as you can run the following in your terminal:
+
+```bash
+git --version
+```
+
+## GitHub
+
+For the Git part of the course, you require access to GitHub. You will need to
+
+1. [Sign up](https://github.com/join), if you haven't already
+2. [Generate an SSH key pair](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+3. [Add the public key to your GitHub account and the private key to your computer's keychain](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+4. Lastly, you should [test your SSH connection](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)
 
 ## Homebrew
 
@@ -67,13 +80,13 @@ echo export PATH='/usr/local/bin:$PATH' >> ~/.bash_profile
 
 and reopen the terminal. Verify that this is correctly installed by executing
 
-```
+```bash
 python --version
 ```
 
 Which should print:
 
-```
+```bash
 Python 3.8.x
 ```
 

--- a/course_prerequisites/02_windows.md
+++ b/course_prerequisites/02_windows.md
@@ -20,23 +20,35 @@ The [solution](http://stackoverflow.com/questions/13036197/ipython-notebook-gett
 
 ## Git
 
-Install the [GitHub for Windows client](http://windows.github.com/).
+Install the [GitHub Desktop Client](http://windows.github.com/).
 This comes with both a GUI client as well as the [Git Bash](https://gitforwindows.org/) terminal client which we will use during the course.
-You should register with [Github](https://github.com) for an account and sign into the GUI client with this account.
-This will automatically set-up [SSH based authentication](https://help.github.com/articles/generating-ssh-keys#platform-windows) for the terminal client.
-The terminal client comes in 3 different flavours based on `Windows CMD` (DOS like), `Windows Powershell`, and `BASH`.
-We will use the `BASH` client as this most closely resembles the `Linux` and `OS X` terminal used by other students.
-In order to configure this open the Github client.
-Sign in with your credentials and:
 
-- Select tools
-- Options
-- Default Shell
-- Git Bash
-- And Press Update to save.
+You'll know it has worked when you can open a Git Bash terminal (the window should have a title that starts with MINGW32) and get the Git version by running
 
-Verify that this is working by opening Git Bash.
-The Shell window should have a title that starts with MINGW32.
+```bash
+git --version
+```
+
+which should show that you have a [recent](https://en.wikipedia.org/wiki/Git#Releases) copy of Git. If your version is more than 18 months old, please update it.
+
+## GitHub
+
+For the Git part of the course, you require access to GitHub. You will need to [sign up](https://github.com/join) and follow either the **GitHub Setup using the Command Line** or **GitHub Setup using the Desktop Client** instructions, below.
+
+### GitHub Setup using the Command Line
+
+1. [Generate an SSH key pair](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+2. [Add the public key to your GitHub account and the private key to your computer's keychain](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+3. [Test your SSH connection](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/testing-your-ssh-connection)
+
+### GitHub Setup using the Desktop Client
+
+1. Signing in to the GitHub Desktop Client should automatically set-up [SSH based authentication](https://help.github.com/articles/generating-ssh-keys#platform-windows) for the terminal client
+2. Configure the default terminal client (there are three different flavours of terminal on Windows: `Windows CMD` (DOS like), `Windows Powershell`, and `BASH`) to use BASH, as this most closely resembles the `Linux` and `macOS` terminal used by other students:
+    1. In the Desktop Client, select **Tools**
+    2. Then **Options**
+    3. **Default Shell**
+    4. **Git Bash**
 
 ## Editor
 


### PR DESCRIPTION
Add more detailed Git/GitHub instructions now that learners will need to use SSH keys for the latter