### PR TITLE
Change reference in workflow from 'master' to 'main'

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -3,7 +3,7 @@ name: Build documentation
 # Run workflow on pushes to matching branches
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 # checkout needs 'contents:read'
 # deploy needs 'contents:write'


### PR DESCRIPTION
We don't seem to have a `master` branch so I think we want the workflow to trigger on merges to `main` instead.