### PR TITLE
Change HEAD^ to HEAD~

### DIFF
--- a/module04_version_control_with_git/04_02_fixing_mistakes.ipynb
+++ b/module04_version_control_with_git/04_02_fixing_mistakes.ipynb
@@ -44,13 +44,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Referring to changes with HEAD and ^\n",
+    "## Referring to changes with HEAD and ~\n",
     "\n",
     "The commit we want to revert to is the one before the latest.\n",
     "\n",
     "`HEAD` refers to the latest commit. That is, we want to go back to the change before the current `HEAD`. \n",
     "\n",
-    "We could use the hash code (e.g. 73fbeaf) to reference this, but you can also refer to the commit before the `HEAD` as `HEAD^`, the one before that as `HEAD^^`, the one before that as `HEAD~3`."
+    "We could use the hash code (e.g. 73fbeaf) to reference this, but you can also refer to the commit before the `HEAD` as `HEAD~`, the one before that as `HEAD~~`, the one before that as `HEAD~3`."
    ]
   },
   {
@@ -80,7 +80,7 @@
    ],
    "source": [
     "%%bash\n",
-    "git revert HEAD^"
+    "git revert HEAD~"
    ]
   },
   {
@@ -366,7 +366,7 @@
    ],
    "source": [
     "%%bash\n",
-    "git reset HEAD^"
+    "git reset HEAD~"
    ]
   },
   {
@@ -582,7 +582,7 @@
     "participant \"Jim's index\" as I\n",
     "participant Jim as J\n",
     "\n",
-    "note right of J: git revert HEAD^\n",
+    "note right of J: git revert HEAD~\n",
     "\n",
     "J->R: Add new commit reversing change\n",
     "R->I: update staging area to reverted version\n",
@@ -595,7 +595,7 @@
     "J->I: Add mistake\n",
     "I->R: Add mistake\n",
     "\n",
-    "note right of J: git reset HEAD^\n",
+    "note right of J: git reset HEAD~\n",
     "\n",
     "J->R: Delete mistaken commit\n",
     "R->I: Update staging area to reset commit\n",

--- a/module04_version_control_with_git/04_10_rebasing.ipynb
+++ b/module04_version_control_with_git/04_10_rebasing.ipynb
@@ -273,7 +273,7 @@
     "If we type \n",
     "\n",
     "``` bash\n",
-    "git rebase -i ab11 #OR HEAD^^\n",
+    "git rebase -i ab11 # OR HEAD~~\n",
     "```\n",
     "\n",
     "an edit window pops up with:"


### PR DESCRIPTION
## Reasoning

We already mention `~` in 04_02_fixing_mistakes.ipynb so we should either stick with one or the other. I don't have a strong preference but...
- `^` is a special char in cmd.exe
- `HEAD~2` is a nice shorthand for `HEAD~~` whereas `HEAD^2` is not the same as `HEAD^^`

From `man gitrevisions` 

```
       <rev>^[<n>], e.g. HEAD^, v1.5.1^0
           A suffix ^ to a revision parameter means the first parent of that commit object.  ^<n> means the <n>th
           parent (i.e.  <rev>^ is equivalent to <rev>^1). As a special rule, <rev>^0 means the commit itself and
           is used when <rev> is the object name of a tag object that refers to a commit object.

       <rev>~[<n>], e.g. HEAD~, master~3
           A suffix ~ to a revision parameter means the first parent of that commit object. A suffix ~<n> to a
           revision parameter means the commit object that is the <n>th generation ancestor of the named commit
           object, following only the first parents. I.e.  <rev>~3 is equivalent to <rev>^^^ which is equivalent
           to <rev>^1^1^1. See below for an illustration of the usage of this form.
```

## Other Options

- There aren't many uses of either shortcut in the docs so we could do away with them all together
- We could keep both but explain the difference
