### PR TITLE
Update eligibility requirements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ This is a relatively short course (8-10 half-day modules) which is intensive and
 - Experience with version control and/or the `Unix` shell, for instance from Software Carpentry, would also be helpful.
 - You should bring your own laptop to the course as there are several hands-on exercise for you to work through.
 - We have provided [setup](course_prerequisites/index.md) instructions for installing the software needed for the course on your computer.
-- **Eligibility:** This course is primarily aimed at Turing-connected PhD students. Other Turing-affiliated people might join too if capacity allows.
+- **Eligibility:** The course is open to postgraduate students, early career researchers, practitioners (e.g. data analysts/scientists) and researchers interested in to learn how to construct reliable, readable, efficient research software in a collaborative environment. Turing PhD students and researchers are particularly encouraged to apply. Attendance is free.
 
 ## Instructors
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ This is a relatively short course (8-10 half-day modules) which is intensive and
 ## Pre-requisites
 
 - It would be helpful to have experience in at least one programming language (for example `C++`, `C`, `Fortran`, `Python`, `Ruby`, `Matlab` or `R`) but this is not a requirement.
-- Experience with version control and/or the `Unix` shell, for instance from Software Carpentry, would also be helpful.
+- Experience with [version control](https://swcarpentry.github.io/git-novice/) and/or the [`Unix` shell](https://swcarpentry.github.io/shell-novice/), for instance from Software Carpentry, would also be helpful.
 - You should bring your own laptop to the course as there are several hands-on exercise for you to work through.
 - We have provided [setup](course_prerequisites/index.md) instructions for installing the software needed for the course on your computer.
 - **Eligibility:** The course is open to postgraduate students, early career researchers, practitioners (e.g. data analysts/scientists) and researchers interested in to learn how to construct reliable, readable, efficient research software in a collaborative environment. Turing PhD students and researchers are particularly encouraged to apply. Attendance is free.


### PR DESCRIPTION
On the course website we stated "This course is primarily aimed at Turing-connected PhD students. Other Turing-affiliated people might join too if capacity allows." but the public advert (https://www.eventsforce.net/turingevents/frontend/reg/thome.csp?pageID=72112&eventID=210&traceRedir=2) says "The course is open to postgraduate students, early career researchers, practitioners (e.g. data analysts/scientists) and researchers interested in to learn how to construct reliable, readable, efficient research software in a collaborative environment. Turing PhD students and researchers are particularly encouraged to apply. Attendance is free.".

Updating the GitHub requirements to match the events page.