### PR TITLE
Fix Chocolatey link in module 6

### DIFF
--- a/module06_software_projects/06_01_installing_packages.ipynb
+++ b/module06_software_projects/06_01_installing_packages.ipynb
@@ -378,7 +378,7 @@
     "- Ubuntu and Debian: [dpkg](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html) for `apt-get` \n",
     "- Redhat and Fedora: [rpm](https://rpm.org/) for `yum`\n",
     "- Mac OS: [homebrew](https://brew.sh/)\n",
-    "- Windows: [Chocolatey]((https://chocolatey.org))\n",
+    "- Windows: [Chocolatey](https://chocolatey.org)\n",
     "\n",
     "If you're working in a compiled language like C++ or Fortran, there's often no language specific repository. You'll need to write platform installers for as many platforms as you want to support."
    ]


### PR DESCRIPTION
It had an extra set of brackets