### PR TITLE
remove mako stuff that depends on previous module from 10.3

### DIFF
--- a/module10_scientific_file_formats/10_03_markup_languages.ipynb
+++ b/module10_scientific_file_formats/10_03_markup_languages.ipynb
@@ -27,13 +27,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One of the easiest ways to make a markup-language based fileformat is the use of a *templating language*."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "We want to represent the chemical reactions:\n",
     "$C_6H_{12}O_6 + 6O_2 \\rightarrow 6CO_2 + 6H_2O\\\\ \n",
     "2H_2 + O_2 \\rightarrow 2H_2O$\n",

--- a/module10_scientific_file_formats/10_03_markup_languages.ipynb
+++ b/module10_scientific_file_formats/10_03_markup_languages.ipynb
@@ -31,143 +31,72 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We want to represent the chemical reactions:\n",
+    "$C_6H_{12}O_6 + 6O_2 \\rightarrow 6CO_2 + 6H_2O\\\\ \n",
+    "2H_2 + O_2 \\rightarrow 2H_2O$\n",
+    "\n",
+    "In xml this might look like:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle C_6H_{12}O_6 + 6O_2 \\rightarrow 6CO_2 + 6H_2O\\\\ \n",
-       "2H_2 + O_2 \\rightarrow 2H_2O$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from IPython.display import Math, display\n",
-    "from parsereactions import parser\n",
-    "\n",
-    "with open(\"system.tex\", \"r\") as f_latex:\n",
-    "    system = parser.parse(f_latex.read())\n",
-    "display(Math(str(system)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing chemistry_template.mko\n"
+      "Overwriting system.xml\n"
      ]
     }
    ],
    "source": [
-    "%%writefile chemistry_template.mko\n",
+    "%%writefile system.xml\n",
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
     "<system>\n",
-    "%for reaction in reactions:\n",
     "    <reaction>\n",
     "        <reactants>\n",
-    "        %for molecule in reaction.reactants.molecules:\n",
-    "            <molecule stoichiometry=\"${reaction.reactants.molecules[molecule]}\">\n",
-    "            %for element in molecule.elements:\n",
-    "                <atom symbol=\"${element.symbol}\" number=\"${molecule.elements[element]}\"/>\n",
-    "            %endfor\n",
+    "            <molecule stoichiometry=\"1\">\n",
+    "                <atom symbol=\"C\" number=\"6\"/>\n",
+    "                <atom symbol=\"H\" number=\"12\"/>\n",
+    "                <atom symbol=\"O\" number=\"6\"/>\n",
     "            </molecule>\n",
-    "        %endfor\n",
+    "            <molecule stoichiometry=\"6\">\n",
+    "                <atom symbol=\"O\" number=\"2\"/>\n",
+    "            </molecule>\n",
     "        </reactants>\n",
     "        <products>\n",
-    "        %for molecule in reaction.products.molecules:\n",
-    "            <molecule stoichiometry=\"${reaction.products.molecules[molecule]}\">\n",
-    "            %for element in molecule.elements:\n",
-    "                <atom symbol=\"${element.symbol}\" number=\"${molecule.elements[element]}\"/>\n",
-    "            %endfor\n",
+    "            <molecule stoichiometry=\"6\">\n",
+    "                <atom symbol=\"C\" number=\"1\"/>\n",
+    "                <atom symbol=\"O\" number=\"2\"/>\n",
     "            </molecule>\n",
-    "        %endfor\n",
+    "            <molecule stoichiometry=\"6\">\n",
+    "                <atom symbol=\"H\" number=\"2\"/>\n",
+    "                <atom symbol=\"O\" number=\"1\"/>\n",
+    "            </molecule>\n",
     "        </products>\n",
     "    </reaction>\n",
-    "%endfor\n",
-    "</system>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from mako.template import Template\n",
-    "\n",
-    "mytemplate = Template(filename=\"chemistry_template.mko\")\n",
-    "with open(\"system.xml\", \"w\") as xmlfile:\n",
-    "    xmlfile.write((mytemplate.render(**vars(system))))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
-      "<system>\r\n",
-      "    <reaction>\r\n",
-      "        <reactants>\r\n",
-      "            <molecule stoichiometry=\"1\">\r\n",
-      "                <atom symbol=\"C\" number=\"6\"/>\r\n",
-      "                <atom symbol=\"H\" number=\"12\"/>\r\n",
-      "                <atom symbol=\"O\" number=\"6\"/>\r\n",
-      "            </molecule>\r\n",
-      "            <molecule stoichiometry=\"6\">\r\n",
-      "                <atom symbol=\"O\" number=\"2\"/>\r\n",
-      "            </molecule>\r\n",
-      "        </reactants>\r\n",
-      "        <products>\r\n",
-      "            <molecule stoichiometry=\"6\">\r\n",
-      "                <atom symbol=\"C\" number=\"1\"/>\r\n",
-      "                <atom symbol=\"O\" number=\"2\"/>\r\n",
-      "            </molecule>\r\n",
-      "            <molecule stoichiometry=\"6\">\r\n",
-      "                <atom symbol=\"H\" number=\"2\"/>\r\n",
-      "                <atom symbol=\"O\" number=\"1\"/>\r\n",
-      "            </molecule>\r\n",
-      "        </products>\r\n",
-      "    </reaction>\r\n",
-      "    <reaction>\r\n",
-      "        <reactants>\r\n",
-      "            <molecule stoichiometry=\"2\">\r\n",
-      "                <atom symbol=\"H\" number=\"2\"/>\r\n",
-      "            </molecule>\r\n",
-      "            <molecule stoichiometry=\"1\">\r\n",
-      "                <atom symbol=\"O\" number=\"2\"/>\r\n",
-      "            </molecule>\r\n",
-      "        </reactants>\r\n",
-      "        <products>\r\n",
-      "            <molecule stoichiometry=\"2\">\r\n",
-      "                <atom symbol=\"H\" number=\"2\"/>\r\n",
-      "                <atom symbol=\"O\" number=\"1\"/>\r\n",
-      "            </molecule>\r\n",
-      "        </products>\r\n",
-      "    </reaction>\r\n",
-      "</system>\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "!cat system.xml"
+    "    <reaction>\n",
+    "        <reactants>\n",
+    "            <molecule stoichiometry=\"2\">\n",
+    "                <atom symbol=\"H\" number=\"2\"/>\n",
+    "            </molecule>\n",
+    "            <molecule stoichiometry=\"1\">\n",
+    "                <atom symbol=\"O\" number=\"2\"/>\n",
+    "            </molecule>\n",
+    "        </reactants>\n",
+    "        <products>\n",
+    "            <molecule stoichiometry=\"2\">\n",
+    "                <atom symbol=\"H\" number=\"2\"/>\n",
+    "                <atom symbol=\"O\" number=\"1\"/>\n",
+    "            </molecule>\n",
+    "        </products>\n",
+    "    </reaction>\n",
+    "</system>    "
    ]
   },
   {
@@ -175,130 +104,6 @@
    "metadata": {},
    "source": [
     "Markup languages are verbose (jokingly called the \"angle bracket tax\") but very clear."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Data as text"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The above serialisation specifies all data as XML \"Attributes\". An alternative is to put the data in the text:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Writing chemistry_template2.mko\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%writefile chemistry_template2.mko\n",
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
-    "<system>\n",
-    "%for reaction in reactions:\n",
-    "    <reaction>\n",
-    "        <reactants>\n",
-    "        %for molecule in reaction.reactants.molecules:\n",
-    "            <molecule stoichiometry=\"${reaction.reactants.molecules[molecule]}\">\n",
-    "            %for element in molecule.elements:\n",
-    "                <atom symbol=\"${element.symbol}\">${molecule.elements[element]}</atom>\n",
-    "            %endfor\n",
-    "            </molecule>\n",
-    "        %endfor\n",
-    "        </reactants>\n",
-    "        <products>\n",
-    "        %for molecule in reaction.products.molecules:\n",
-    "            <molecule stoichiometry=\"${reaction.products.molecules[molecule]}\">\n",
-    "            %for element in molecule.elements:\n",
-    "                <atom symbol=\"${element.symbol}\">${molecule.elements[element]}</atom>\n",
-    "            %endfor\n",
-    "            </molecule>\n",
-    "        %endfor\n",
-    "        </products>\n",
-    "    </reaction>\n",
-    "%endfor\n",
-    "</system>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mytemplate = Template(filename=\"chemistry_template2.mko\")\n",
-    "with open(\"system2.xml\", \"w\") as xmlfile:\n",
-    "    xmlfile.write((mytemplate.render(**vars(system))))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
-      "<system>\r\n",
-      "    <reaction>\r\n",
-      "        <reactants>\r\n",
-      "            <molecule stoichiometry=\"1\">\r\n",
-      "                <atom symbol=\"C\">6</atom>\r\n",
-      "                <atom symbol=\"H\">12</atom>\r\n",
-      "                <atom symbol=\"O\">6</atom>\r\n",
-      "            </molecule>\r\n",
-      "            <molecule stoichiometry=\"6\">\r\n",
-      "                <atom symbol=\"O\">2</atom>\r\n",
-      "            </molecule>\r\n",
-      "        </reactants>\r\n",
-      "        <products>\r\n",
-      "            <molecule stoichiometry=\"6\">\r\n",
-      "                <atom symbol=\"C\">1</atom>\r\n",
-      "                <atom symbol=\"O\">2</atom>\r\n",
-      "            </molecule>\r\n",
-      "            <molecule stoichiometry=\"6\">\r\n",
-      "                <atom symbol=\"H\">2</atom>\r\n",
-      "                <atom symbol=\"O\">1</atom>\r\n",
-      "            </molecule>\r\n",
-      "        </products>\r\n",
-      "    </reaction>\r\n",
-      "    <reaction>\r\n",
-      "        <reactants>\r\n",
-      "            <molecule stoichiometry=\"2\">\r\n",
-      "                <atom symbol=\"H\">2</atom>\r\n",
-      "            </molecule>\r\n",
-      "            <molecule stoichiometry=\"1\">\r\n",
-      "                <atom symbol=\"O\">2</atom>\r\n",
-      "            </molecule>\r\n",
-      "        </reactants>\r\n",
-      "        <products>\r\n",
-      "            <molecule stoichiometry=\"2\">\r\n",
-      "                <atom symbol=\"H\">2</atom>\r\n",
-      "                <atom symbol=\"O\">1</atom>\r\n",
-      "            </molecule>\r\n",
-      "        </products>\r\n",
-      "    </reaction>\r\n",
-      "</system>\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "!cat system2.xml"
    ]
   },
   {
@@ -317,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -385,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -394,7 +199,7 @@
        "'6'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -437,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -446,7 +251,7 @@
        "['C', 'O', 'O']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -470,34 +275,6 @@
    "metadata": {},
    "source": [
     "The above says: \"For element in molecules where number is one, return symbol\", roughly equivalent to `[element.symbol for element in molecule for molecule in document if element.number==1]` in Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['C', 'O', 'H', 'O', 'H', 'O']\n"
-     ]
-    }
-   ],
-   "source": [
-    "with open(\"system2.xml\") as xmlfile:\n",
-    "    tree2 = etree.parse(xmlfile)\n",
-    "# For all molecules with a child atom whose text is 1\n",
-    "# ... return the symbol attribute of any child (however deeply nested)\n",
-    "print(tree2.xpath(\"//molecule[atom=1]//@symbol\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note how we select on text content rather than attributes by using the element tag directly. The above says \"for every molecule where at least one element is present with just a single atom, return all the symbols of all the elements in that molecule.\""
    ]
   },
   {
@@ -532,14 +309,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing xmltotex.xsl\n"
+      "Overwriting xmltotex.xsl\n"
      ]
     }
    ],
@@ -604,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -634,28 +411,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 15,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle C_6H_{12}O_6 + 6O_2 \\rightarrow 6CO_2 + 6H_2O\\\\\n",
-       "2H_2 + O_2 \\rightarrow 2H_2O\\\\\n",
-       "\n",
-       "$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
    "source": [
-    "display(Math(str(transform(tree))))"
+    "Which is back to the LaTeX representation of our reactions."
    ]
   },
   {
@@ -676,14 +435,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing reactions.xsd\n"
+      "Overwriting reactions.xsd\n"
      ]
     }
    ],
@@ -742,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -771,7 +530,7 @@
        "['C', 'H', 'O', 'O', 'C', 'O', 'H', 'O', 'H', 'O', 'H', 'O']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -792,14 +551,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing invalid_system.xml\n"
+      "Overwriting invalid_system.xml\n"
      ]
     }
    ],
@@ -828,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Cut down the chapter on markup languages, to remove the material that depends on the domain-specific-languages notebook.
i.e. the cells around mako templating are removed, while the cells describing parsing and navigating xml are retained.