### PR TITLE
Fix error in package installation from GitHub

### DIFF
--- a/module06_software_projects/06_04_packaging.ipynb
+++ b/module06_software_projects/06_04_packaging.ipynb
@@ -423,7 +423,7 @@
    "metadata": {},
    "source": [
     "```bash\n",
-    "pip install git+git://github.com/alan-turing-institute/Greetings\n",
+    "pip install git+https://github.com/alan-turing-institute/Greetings\n",
     "```"
    ]
   },


### PR DESCRIPTION
`pip install` with `git+git` no longer works, it should be `git+https`, see [here](https://stackoverflow.com/questions/72915782/fatal-unable-to-connect-to-github-com-github-com0-140-82-121-3-errno-opera). Credit to @craddm for pointing me to this solution.