### PR TITLE
Update 04_00_introduction.ipynb

### DIFF
--- a/module04_version_control_with_git/04_00_introduction.ipynb
+++ b/module04_version_control_with_git/04_00_introduction.ipynb
@@ -152,7 +152,7 @@
     "The text files we create will use a simple \"wiki\" markup style called [markdown](http://daringfireball.net/projects/markdown/basics) to show formatting.\n",
     "This is the convention used in this file, too.\n",
     "\n",
-    "You can view the content of this file in the way Markdown renders it by looking on the [web](https://github.com/alan-turing-institute/rse-course/blob/main/module04_version_control_with_git/04_00_introduction.html), and compare the [raw text](https://raw.githubusercontent.com/alan-turing-institute/rse-course/main/module04_version_control_with_git/04_00_introduction.ipynb)."
+    "You can view the content of this file in the way Markdown renders it by looking on the [web](https://alan-turing-institute.github.io/rse-course/html/module04_version_control_with_git/04_00_introduction.html), and compare the [raw text](https://raw.githubusercontent.com/alan-turing-institute/rse-course/main/module04_version_control_with_git/04_00_introduction.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
Original link to HTML-formatted version of notebook is to a non-existent/non-extant file (https://github.com/alan-turing-institute/rse-course/blob/main/module04_version_control_with_git/04_00_introduction.html). Updated to confirmed version: https://alan-turing-institute.github.io/rse-course/html/module04_version_control_with_git/04_00_introduction.html