### PR TITLE
Run nbqa black

### DIFF
--- a/.github/workflows/lint_code.yaml
+++ b/.github/workflows/lint_code.yaml
@@ -20,31 +20,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Install poetry
-        run: |
-          pipx install poetry
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        id: poetry-cache
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
-      - name: Install dependencies
-        shell: bash
-        if: steps.poetry-cache.outputs.cache-hit != 'true'
-        run: |
-          poetry update
-          python -m poetry config virtualenvs.in-project true
-          python -m poetry install --no-root
+      
+      - name: Install linters
+        run: pip install -r requirements.txt
       - name: Run black
-        run: poetry run nbqa black module*/*.ipynb --nbqa-diff --verbose
+        run: nbqa black module*/*.ipynb --nbqa-diff --verbose
       - name: Run isort
-        run: poetry run nbqa isort module*/*.ipynb --nbqa-diff
+        run: nbqa isort module*/*.ipynb --nbqa-diff
       - name: Run pycodestyle
-        run: poetry run nbqa pycodestyle module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,W503
+        run: nbqa pycodestyle module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,W503
       - name: Run flake8
-        run: poetry run nbqa flake8 module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,F403,F405,F632,F811,F821,W503
+        run: nbqa flake8 module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,F403,F405,F632,F811,F821,W503

--- a/.github/workflows/lint_code.yaml
+++ b/.github/workflows/lint_code.yaml
@@ -16,13 +16,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Install linters
-        run: pip install black flake8 isort nbqa pylint
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install required packages
+        run: |
+          poetry update
+          poetry install --no-root
       - name: Run black
-        run: nbqa black module*/*.ipynb --nbqa-diff --verbose
+        run: poetry run nbqa black module*/*.ipynb --nbqa-diff --verbose
       - name: Run isort
-        run: nbqa isort module*/*.ipynb --nbqa-diff
+        run: poetry run nbqa isort module*/*.ipynb --nbqa-diff
       - name: Run pycodestyle
-        run: nbqa pycodestyle module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,W503
+        run: poetry run nbqa pycodestyle module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,W503
       - name: Run flake8
-        run: nbqa flake8 module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,F403,F405,F632,F811,F821,W503
+        run: poetry run nbqa flake8 module*/*.ipynb --nbqa-diff --ignore=E203,E402,E501,E712,E722,E731,F403,F405,F632,F811,F821,W503

--- a/.github/workflows/lint_code.yaml
+++ b/.github/workflows/lint_code.yaml
@@ -1,31 +1,45 @@
 name: Lint all repository code
 
-# Run workflow on PRs to main
 on:
+  # Run workflow on PRs to main
   pull_request:
     branches: [main]
+  # Run on merge to main because caches are inherited from parent branches
+  push:
+    branches:
+      - main
 
 # checkout needs 'contents:read'
 permissions:
   contents: read
 
 jobs:
-    # Note that we have to ignore a *lot* of cases as in many places the modules are deliberately showing incorrect code
+  # Note that we have to ignore a *lot* of cases as in many places the modules are deliberately showing incorrect code
   lint_notebooks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install poetry
-        run: pipx install poetry
+        run: |
+          pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - name: Install required packages
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        id: poetry-cache
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+      - name: Install dependencies
+        shell: bash
+        if: steps.poetry-cache.outputs.cache-hit != 'true'
         run: |
           poetry update
-          poetry install --no-root
+          python -m poetry config virtualenvs.in-project true
+          python -m poetry install --no-root
       - name: Run black
         run: poetry run nbqa black module*/*.ipynb --nbqa-diff --verbose
       - name: Run isort


### PR DESCRIPTION
Since we `pip install black`, we get the latest version each time the action runs. We could either pin it in the action for more stability or incorporate the new formatting as and when it happens (which is what this PR does but I'm happy to change to the other strategy).