### PR TITLE
Update 04_05_fork_and_pull.ipynb

### DIFF
--- a/module04_version_control_with_git/04_05_fork_and_pull.ipynb
+++ b/module04_version_control_with_git/04_05_fork_and_pull.ipynb
@@ -112,6 +112,7 @@
     "We'll learn more about branches later on.\n",
     "For now, just think of this as a separate area where our changes will be kept not to interfere with other people's work.\n",
     "\n",
+    "(Be sure to first navigate to the cloned directory, or git commands will not use this repository: `cd github-example`)\n",
     "```\n",
     "git checkout -b southwest\n",
     "```"


### PR DESCRIPTION
Added reminder for user to navigate into cloned directory before creating a feature branch. Otherwise, git fails to use the required repo.