### PR TITLE
Correct typo in 04_08_advanced_git_concepts.ipynb

### DIFF
--- a/module04_version_control_with_git/04_08_advanced_git_concepts.ipynb
+++ b/module04_version_control_with_git/04_08_advanced_git_concepts.ipynb
@@ -545,7 +545,7 @@
    "source": [
     "* With `-f`: don't prompt\n",
     "* with `-d`: remove directories\n",
-    "* with `-x`: Also remote `.gitignored` files\n",
+    "* with `-x`: Also remove `.gitignored` files\n",
     "* with `-X`: Only remove `.gitignored` files"
    ]
   },


### PR DESCRIPTION
Corrected note on `git clean -x`: `remote` should be `remove`