### PR TITLE
Correct URL typo in 04_09_github_pages.ipynb

### DIFF
--- a/module04_version_control_with_git/04_09_github_pages.ipynb
+++ b/module04_version_control_with_git/04_09_github_pages.ipynb
@@ -158,7 +158,7 @@
    "source": [
     "## Layout for GitHub pages\n",
     "\n",
-    "You can use GitHub pages to make HTML layouts, here's an [example of how to do it](http://github.com/UCL/ucl-github-pages-example), and [how it looks](http://ucl.github.com/ucl-github-pages-example). We won't go into the detail of this now, but after the class, you might want to try this."
+    "You can use GitHub pages to make HTML layouts, here's an [example of how to do it](http://github.com/UCL/ucl-github-pages-example), and [how it looks](http://ucl.github.io/ucl-github-pages-example). We won't go into the detail of this now, but after the class, you might want to try this."
    ]
   },
   {


### PR DESCRIPTION
Under *Layout for GitHub pages*, the "how it looks" link is incorrect. I have changed `.com` to `.io` in the URL, and tested it redirects correctly.